### PR TITLE
Improving exceptions and responses

### DIFF
--- a/django_rest/decorators/utils.py
+++ b/django_rest/decorators/utils.py
@@ -19,6 +19,7 @@ from django_rest.http.exceptions import (
     InternalServerError,
     MethodNotAllowed,
     PermissionDenied,
+    UnsupportedMediaType,
 )
 from django_rest.http.methods import SUPPORTING_PAYLOAD_METHODS
 from django_rest.permissions import BasePermission
@@ -69,7 +70,7 @@ def extract_request_payload(request, allow_form_data=False):
     For `POST`, `PUT` and `PATCH` requests:
     - If the form data is allowed and the request is a form, returns a `dict`
     - If the form data isn't allowed and the request is a form, raises
-      PermissionDenied exception.
+      UnsupportedMediaType exception.
     - For application/json requests, returns a `dict` containing the request's
       data
     For other HTTP methods:
@@ -77,7 +78,7 @@ def extract_request_payload(request, allow_form_data=False):
     """
     method = request.method
     if not allow_form_data and request.content_type in FORMS_CONTENT_TYPES:
-        raise PermissionDenied  # OR bad request ?
+        raise UnsupportedMediaType
     elif request.content_type in FORMS_CONTENT_TYPES and request.method == "POST":
         return transform_query_dict_into_regular_dict(request.POST)
 

--- a/django_rest/deserializers/__init__.py
+++ b/django_rest/deserializers/__init__.py
@@ -2,4 +2,4 @@
 
 from django.forms import fields
 
-from django_rest.deserializers.base import Deserializer, AllPassDeserializer
+from django_rest.deserializers.base import Deserializer, AllPassDeserializer, ValidationError

--- a/django_rest/http/exceptions.py
+++ b/django_rest/http/exceptions.py
@@ -41,6 +41,11 @@ class MethodNotAllowed(BaseAPIException):
     RESPONSE_MESSAGE = "HTTP Method not allowed."
 
 
+class UnsupportedMediaType(BaseAPIException):
+    STATUS_CODE = status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+    RESPONSE_MESSAGE = "Unsupported Media Type. Check your request's Content-Type."
+
+
 class InternalServerError(BaseAPIException):
     pass
 

--- a/django_rest/serializers/serializers.py
+++ b/django_rest/serializers/serializers.py
@@ -115,7 +115,7 @@ class Serializer(six.with_metaclass(SerializerMeta, SerializerBase)):
                             result = result()
                         if to_value:
                             result = to_value(result)
-            except (KeyError, AttributeError, TypeError) as e:
+            except (KeyError, AttributeError, TypeError, ValueError) as e:
                 if required:
                     raise SerializationError(str(e))
             else:

--- a/tests/tests/decorators/test_base.py
+++ b/tests/tests/decorators/test_base.py
@@ -21,7 +21,7 @@ from django_rest.deserializers import Deserializer, AllPassDeserializer
 from django_rest.http.exceptions import (
     BaseAPIException,
     InternalServerError,
-    PermissionDenied,
+    UnsupportedMediaType,
 )
 from django_rest.permissions import AllowAny, BasePermission
 
@@ -169,7 +169,7 @@ def test_extract_payload_from_post_method_form():
         "foo": "bar",
         "baz": "3",
     }
-    with pytest.raises(PermissionDenied):
+    with pytest.raises(UnsupportedMediaType):
         extract_request_payload(request, allow_form_data=False)
 
 


### PR DESCRIPTION
* Catching `ValueError` in `Serializer`'s serialization method, in order to throw `SerializationError` instead
* Making `ValueError` available in `django_rest.deserializers` (instead of importing it from `django`)
* In case `allow_forms` parameter is set to `False` (in `@api_view` decorator), it returns a `415 Unsupported Media Type` instead of `403 Forbidden`